### PR TITLE
updating to zig 0.14.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /zig-cache
 /zig-out
+/.zig-cache

--- a/build.zig
+++ b/build.zig
@@ -6,10 +6,13 @@ pub fn build(b: *std.Build) void {
 
     const upstream = b.dependency("openssl", .{});
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "openssl",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
 
     const ssl_dir_flag = switch (target.result.os.tag) {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,12 +1,14 @@
 .{
-    .name = "openssl",
-    .version = "3.3.1-1",
-    .minimum_zig_version = "0.12.0-dev.3644+05d975576",
+    .name = .openssl,
+    .version = "3.3.1-2",
+    .fingerprint = 0x773a47f1c9b1d415, // Changing this has security and trust implications.
+
+    .minimum_zig_version = "0.14.0",
 
     .dependencies = .{
         .openssl = .{
             .url = "https://github.com/openssl/openssl/releases/download/openssl-3.3.0/openssl-3.3.0.tar.gz",
-            .hash = "1220d9c400445c9c3ed46f71ebdbc364b7b349473231884c2f6e540817d7b68553ae",
+            .hash = "N-V-__8AAIg12QPZxABEXJw-1G9x69vDZLezSUcyMYhML25U",
         },
     },
 


### PR DESCRIPTION
This updates build.zig and build.zig.zon to work with zig 0.14.0. I tested this against the cpython project and all seems to be running there. I bumped the version suffix so that this could get a unique tag. If there's some other process that's preferred let me know. 